### PR TITLE
debian2docker support

### DIFF
--- a/Formula/azk.rb
+++ b/Formula/azk.rb
@@ -7,7 +7,6 @@ class Azk < Formula
 
   depends_on :macos => :mountain_lion
   depends_on :arch => :x86_64
-  depends_on "unfs3"
 
   def install
     prefix.install Dir['*']

--- a/Formula/azk.rb
+++ b/Formula/azk.rb
@@ -2,8 +2,8 @@ require "formula"
 
 class Azk < Formula
   homepage "http://azk.io"
-  url "http://repo.azukiapp.com/mac/azk_0.9.2.tar.gz"
-  sha256 "c6dc5d0f7cabfe211c67aecbc559e74d045d3b6f879679ceae5bd69c32f6b1a9"
+  url "http://repo.azukiapp.com/mac/azk_0.10.0.tar.gz"
+  sha256 "4f6db2fcc78a1daf24b9a94d9a44430a717c3f6a7d9c48d2b0c7449b0d307eae"
 
   depends_on :macos => :mountain_lion
   depends_on :arch => :x86_64


### PR DESCRIPTION
Removed `unfs3` dependency for new `azk` version using debian2docker. We no longer rely on `unfs3` file sharing due its unstable behaviour. Now using VirtualBox shared folder.
