### PR TITLE
Correct azk formula version

### DIFF
--- a/Formula/azk.rb
+++ b/Formula/azk.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class Azk < Formula
   homepage "http://azk.io"
-  url "http://repo.azukiapp.com/mac/azk_0.10.2.tar.gz"
+  url "http://repo.azukiapp.com/mac/azk_0.11.0.tar.gz"
   sha256 "80295967f11856660d3e373b58039e93960fc5013b0ae3f1f9342e8eec2f08af"
 
   depends_on :macos => :mountain_lion


### PR DESCRIPTION
sha256 was correct for v0.11.0, but URL to release file was not.

This change corrects this so `brew install azk` works again.

Cheers :heart: :heart: :heart: 
