### PR TITLE
Adding support to '--HEAD' argument

### DIFF
--- a/Formula/azk.rb
+++ b/Formula/azk.rb
@@ -30,7 +30,7 @@ class Azk < Formula
   end
 
   def post_install
-    system 'rm -Rf ./package' if build.head?
+    rmtree './package' if build.head?
   end
 
   test do

--- a/Formula/azk.rb
+++ b/Formula/azk.rb
@@ -5,14 +5,35 @@ class Azk < Formula
   url "http://repo-stage.azukiapp.com/mac/azk_0.17.0.tar.gz"
   version "0.17.0"
   sha256 "aa03f76782b88b285340e31299c2a6cb881645248538dfec50ec8186644614ad"
-  
+  head "https://github.com/azukiapp/azk.git"
+
   depends_on :macos => :mountain_lion
   depends_on :arch => :x86_64
 
   def install
-    prefix.install Dir['*']
-    prefix.install Dir['.nvmrc']
-    prefix.install Dir['.dependencies']
+    items_path = '.'
+    if build.head?
+      ENV.deparallelize
+      ENV['HOMEBREW_TEMP'] = buildpath
+      system 'make', '-e', 'package_mac'
+
+      items_path = 'package/brew/*/usr/lib/azk'
+      items = %w{ bin lib node_modules shared package.json npm-shrinkwrap.json CHANGELOG.md LICENSE README.md }
+    else
+      items = ['*']
+    end
+    items += %w{ .dependencies .nvmrc }
+
+    items.each do |item|
+      prefix.install Dir["#{items_path}/#{item}"]
+    end
+  end
+
+  def post_install
+    system 'rm -Rf ./package' if build.head?
+  end
+
+  test do
+    system "azk", "version"
   end
 end
-


### PR DESCRIPTION
Homebrew supports `--HEAD` argument, which means that the target package should be built and installed from the most up-to-date source code pushed into the code repository.

This PR adds support for this, by:

1) Getting the azk source code from [`master` branch](https://github.com/azukiapp/azk/tree/master) at GitHub;
2) Building `azk` using `make -e package_mac` (which avoid installing unnecessary files and dependencies, such as `node_modules` dev dependencies);
3) Cleaning any remaining generated artifact that won't be used, avoiding waste of disk space.

In my tests, the resulting folder at `/usr/local/Cellar/azk/HEAD` has approximately the same size of the folder for azk `v0.17.0` (from `stage` branch).

This PR supersedes #7 
